### PR TITLE
Add Qwik City blog example

### DIFF
--- a/examples/qwik-city-blog/README.md
+++ b/examples/qwik-city-blog/README.md
@@ -1,0 +1,15 @@
+# Qwik City Blog Example
+
+This example demonstrates a simple blog created with **Qwik City**. It contains a
+basic layout, a blog index page, and a dynamic route for individual posts.
+
+## Development
+
+To start the development server, run:
+
+```bash
+npm install
+npm run dev
+```
+
+This will serve the site on `http://localhost:5173/` by default.

--- a/examples/qwik-city-blog/package.json
+++ b/examples/qwik-city-blog/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "qwik-blog",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@builder.io/qwik": "^0.20.0",
+    "@builder.io/qwik-city": "^0.20.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "typescript": "^4.7.0"
+  }
+}

--- a/examples/qwik-city-blog/src/root.tsx
+++ b/examples/qwik-city-blog/src/root.tsx
@@ -1,0 +1,10 @@
+import { component$, Slot } from '@builder.io/qwik';
+import { RouterOutlet } from '@builder.io/qwik-city';
+
+export default component$(() => {
+  return (
+    <RouterOutlet>
+      <Slot />
+    </RouterOutlet>
+  );
+});

--- a/examples/qwik-city-blog/src/routes/blog/[slug]/index.tsx
+++ b/examples/qwik-city-blog/src/routes/blog/[slug]/index.tsx
@@ -1,0 +1,14 @@
+import { component$, useStore } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
+
+export default component$(() => {
+  const loc = useLocation();
+  const state = useStore({ title: loc.params.slug });
+
+  return (
+    <>
+      <h1>{state.title}</h1>
+      <p>This is a sample blog post using Qwik City.</p>
+    </>
+  );
+});

--- a/examples/qwik-city-blog/src/routes/blog/index.tsx
+++ b/examples/qwik-city-blog/src/routes/blog/index.tsx
@@ -1,0 +1,12 @@
+import { component$ } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <>
+      <h1>Blog Posts</h1>
+      <ul>
+        <li><a href="/blog/hello">Hello Qwik</a></li>
+      </ul>
+    </>
+  );
+});

--- a/examples/qwik-city-blog/src/routes/index.tsx
+++ b/examples/qwik-city-blog/src/routes/index.tsx
@@ -1,0 +1,10 @@
+import { component$ } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <>
+      <h1>Welcome to Qwik City Blog</h1>
+      <p>Visit the <a href="/blog/">blog index</a> to see posts.</p>
+    </>
+  );
+});

--- a/examples/qwik-city-blog/src/routes/layout.tsx
+++ b/examples/qwik-city-blog/src/routes/layout.tsx
@@ -1,0 +1,16 @@
+import { component$, Slot } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <div>
+      <header>
+        <nav>
+          <a href="/">Home</a> | <a href="/blog/">Blog</a>
+        </nav>
+      </header>
+      <main>
+        <Slot />
+      </main>
+    </div>
+  );
+});

--- a/examples/qwik-city-blog/tsconfig.json
+++ b/examples/qwik-city-blog/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "ESNext"],
+    "jsx": "preserve",
+    "jsxImportSource": "@builder.io/qwik",
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.tsx", "src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/qwik-city-blog/vite.config.ts
+++ b/examples/qwik-city-blog/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import { qwikVite } from '@builder.io/qwik/optimizer';
+import { qwikCity } from '@builder.io/qwik-city/vite';
+
+export default defineConfig(() => {
+  return {
+    plugins: [
+      qwikCity(),
+      qwikVite(),
+    ],
+  };
+});


### PR DESCRIPTION
## Summary
- create a `qwik-city-blog` example with minimal Qwik City setup
- add basic routes, layout and configuration

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_684ae7e517608333a1a1d8135d86c55c